### PR TITLE
Use rubygem version of fake_sns

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -9,7 +9,6 @@ RUN set -x  && \
 	apk add --no-cache --virtual \
         .build-deps \
         gcc \
-        git \
         g++ \
         linux-headers \
         musl-dev \
@@ -36,5 +35,4 @@ EXPOSE $SNS_PORT
 CMD fake_sns \
         --bind 0.0.0.0 \
         --database=$MESSAGES_DIR/database.yml \
-        --port $SNS_PORT \
-        --server thin
+        --port $SNS_PORT

--- a/2.2/Gemfile
+++ b/2.2/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'fake_sns', git: 'https://github.com/feathj/fake_sns.git'
+gem 'fake_sns'
 gem 'thin'

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -9,7 +9,6 @@ RUN set -x  && \
 	apk add --no-cache --virtual \
         .build-deps \
         gcc \
-        git \
         g++ \
         linux-headers \
         musl-dev \
@@ -36,5 +35,4 @@ EXPOSE $SNS_PORT
 CMD fake_sns \
         --bind 0.0.0.0 \
         --database=$MESSAGES_DIR/database.yml \
-        --port $SNS_PORT \
-        --server thin
+        --port $SNS_PORT

--- a/2.3/Gemfile
+++ b/2.3/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'fake_sns', git: 'https://github.com/feathj/fake_sns.git'
+gem 'fake_sns'
 gem 'thin'

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -9,7 +9,6 @@ RUN set -x  && \
 	apk add --no-cache --virtual \
         .build-deps \
         gcc \
-        git \
         g++ \
         linux-headers \
         musl-dev \
@@ -36,5 +35,4 @@ EXPOSE $SNS_PORT
 CMD fake_sns \
         --bind 0.0.0.0 \
         --database=$MESSAGES_DIR/database.yml \
-        --port $SNS_PORT \
-        --server thin
+        --port $SNS_PORT

--- a/2.4/Gemfile
+++ b/2.4/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'fake_sns', git: 'https://github.com/feathj/fake_sns.git'
+gem 'fake_sns'
 gem 'thin'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'fake_sns', git: 'https://github.com/feathj/fake_sns.git'
+gem 'fake_sns'
 gem 'thin'


### PR DESCRIPTION
## Changes

- Remove server thin argument to fake_sns
- Use fake_sns from rubygems